### PR TITLE
Update README.md - Pick even numbered font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Once you have installed circup and connected to a board, simply install the desi
 
 ```sh
 circup bundle-add adafruit/circuitpython-fonts # You only need to do this once
-circup install font_free_mono_9
+circup install font_free_mono_8
 ```
 
 The font can be used like so:


### PR DESCRIPTION
This allows the example to be followed without an error (due to only even numbered sizes being in release assets):

Closes #4 