### PR TITLE
Use py312

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Versions
       run: |
         python3 --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v0.12.1
+    rev: v3.0.1
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
I do not think this change is strictly necessary, I made it mostly in order to be able to get a new trigger for the build / release actions to run which should create and upload 10.x mpy builds of these font libraries. 

I believe this should resolve an issue causing circup to print a warning when trying to download this bundle. Though this bundle is non-standard and users must explicitly add it to their own local circup instance with a bundle-add command, so anyone who has not done that would not have this error.